### PR TITLE
fix: CDATA nesting into CDATA is avoided as it is prohibited

### DIFF
--- a/src/cc2olx/constants.py
+++ b/src/cc2olx/constants.py
@@ -1,0 +1,1 @@
+CDATA_PATTERN = r"<!\[CDATA\[(?P<content>.*?)\]\]>"

--- a/src/cc2olx/olx.py
+++ b/src/cc2olx/olx.py
@@ -8,7 +8,7 @@ from lxml import html
 from cc2olx.iframe_link_parser import KalturaIframeLinkParser
 
 from cc2olx.qti import QtiExport
-from cc2olx.utils import element_builder, passport_file_parser
+from cc2olx.utils import clean_from_cdata, element_builder, passport_file_parser
 
 logger = logging.getLogger()
 
@@ -363,6 +363,7 @@ class OlxExport:
         html = self._process_static_links(details["html"])
         if self.link_file:
             html, video_olx = self._process_html_for_iframe(html)
+        html = clean_from_cdata(html)
         txt = self.doc.createCDATASection(html)
         child.appendChild(txt)
         nodes.append(child)
@@ -434,6 +435,7 @@ class OlxExport:
         node.setAttribute("discussion_target", details["title"])
         html_node = self.doc.createElement("html")
         txt = "MISSING CONTENT" if details["text"] is None else details["text"]
+        txt = clean_from_cdata(txt)
         txt = self.doc.createCDATASection(txt)
         html_node.appendChild(txt)
         return [html_node, node]

--- a/src/cc2olx/utils.py
+++ b/src/cc2olx/utils.py
@@ -5,6 +5,8 @@ import string
 import csv
 import re
 
+from cc2olx.constants import CDATA_PATTERN
+
 logger = logging.getLogger()
 
 
@@ -108,3 +110,16 @@ def clean_file_name(filename: str):
 
     cleaned_name = re.sub(special_characters, "_", filename)
     return cleaned_name
+
+
+def clean_from_cdata(xml_string: str) -> str:
+    """
+    Deletes CDATA tag from XML string while keeping its content.
+
+    Args:
+        xml_string (str): original XML string to clean.
+
+    Returns:
+        str: cleaned XML string.
+    """
+    return re.sub(CDATA_PATTERN, r"\g<content>", xml_string, flags=re.DOTALL)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,3 +242,48 @@ def transcript_file(fixtures_data_dir):
         fixtures_data_dir / "video_files/01___Intro_to_Knowledge_Based_AI/0 - Introductions.en.srt"
     )
     return transcript_file_path
+
+
+@pytest.fixture(scope="session")
+def html_without_cdata(fixtures_data_dir: Path) -> str:
+    """
+    HTML string that doesn't contain CDATA sections.
+
+    Args:
+        fixtures_data_dir (str): Path to the directory where fixture data is present.
+
+    Returns:
+        str: HTML string.
+    """
+    html_without_cdata_path = fixtures_data_dir / "html_files/html-without-cdata.html"
+    return html_without_cdata_path.read_text()
+
+
+@pytest.fixture(scope="session")
+def cdata_containing_html(fixtures_data_dir: Path) -> str:
+    """
+    HTML string that contains CDATA sections.
+
+    Args:
+        fixtures_data_dir (str): Path to the directory where fixture data is present.
+
+    Returns:
+        str: HTML string.
+    """
+    html_without_cdata_path = fixtures_data_dir / "html_files/cdata-containing-html.html"
+    return html_without_cdata_path.read_text()
+
+
+@pytest.fixture(scope="session")
+def expected_cleaned_cdata_containing_html(fixtures_data_dir: Path) -> str:
+    """
+    The string with expected HTML after cleaning from CDATA sections.
+
+    Args:
+        fixtures_data_dir (str): Path to the directory where fixture data is present.
+
+    Returns:
+        str: HTML string.
+    """
+    html_without_cdata_path = fixtures_data_dir / "html_files/cleaned-cdata-containing-html.html"
+    return html_without_cdata_path.read_text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import zipfile
 
+import xml.dom.minidom
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from xml.dom.minidom import parse
@@ -12,6 +13,7 @@ import pytest
 
 from cc2olx.cli import parse_args
 from cc2olx.models import Cartridge
+from cc2olx.olx import OlxExport
 from cc2olx.settings import collect_settings
 
 
@@ -287,3 +289,19 @@ def expected_cleaned_cdata_containing_html(fixtures_data_dir: Path) -> str:
     """
     html_without_cdata_path = fixtures_data_dir / "html_files/cleaned-cdata-containing-html.html"
     return html_without_cdata_path.read_text()
+
+
+@pytest.fixture
+def bare_olx_exporter(cartridge: Cartridge) -> OlxExport:
+    """
+    Provides bare OLX exporter.
+
+    Args:
+        cartridge (Cartridge): Cartridge class instance.
+
+    Returns:
+        OlxExport: OlxExport instance.
+    """
+    olx_exporter = OlxExport(cartridge)
+    olx_exporter.doc = xml.dom.minidom.Document()
+    return olx_exporter

--- a/tests/fixtures_data/html_files/cdata-containing-html.html
+++ b/tests/fixtures_data/html_files/cdata-containing-html.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head>
+        <title>CDATA containing HTML document</title>
+    </head>
+    <body>
+        <script type="text/javascript">
+            <![CDATA[
+            var htmlContent = "<div>Hello, world!</div>";
+            alert(htmlContent);
+            ]]>
+        </script>
+    </body>
+</html>

--- a/tests/fixtures_data/html_files/cleaned-cdata-containing-html.html
+++ b/tests/fixtures_data/html_files/cleaned-cdata-containing-html.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head>
+        <title>CDATA containing HTML document</title>
+    </head>
+    <body>
+        <script type="text/javascript">
+            
+            var htmlContent = "<div>Hello, world!</div>";
+            alert(htmlContent);
+            
+        </script>
+    </body>
+</html>

--- a/tests/fixtures_data/html_files/html-without-cdata.html
+++ b/tests/fixtures_data/html_files/html-without-cdata.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head>
+        <title>HTML document without CDATA</title>
+    </head>
+    <body>
+        <script type="text/javascript">
+            var htmlContent = "<div>Hello, world!</div>";
+            alert(htmlContent);
+        </script>
+    </body>
+</html>

--- a/tests/fixtures_data/test_utils.py
+++ b/tests/fixtures_data/test_utils.py
@@ -1,0 +1,35 @@
+from cc2olx.utils import clean_from_cdata
+
+
+class TestXMLCleaningFromCDATA:
+    """
+    Tests XML string cleaning from CDATA sections.
+    """
+
+    def test_cdata_containing_html_is_cleaned_successfully(
+        self,
+        cdata_containing_html: str,
+        expected_cleaned_cdata_containing_html: str,
+    ) -> None:
+        """
+        Test if CDATA tags are removed from HTML while their content is kept.
+
+        Args:
+            cdata_containing_html (str): HTML that contains CDATA tags.
+            expected_cleaned_cdata_containing_html (str): Expected HTML after
+                successful cleaning.
+        """
+        actual_cleaned_cdata_containing_html = clean_from_cdata(cdata_containing_html)
+
+        assert actual_cleaned_cdata_containing_html == expected_cleaned_cdata_containing_html
+
+    def test_html_without_cdata_remains_the_same_after_cleaning(self, html_without_cdata: str) -> None:
+        """
+        Test if HTML that doesn't contain CDATA tags remains the same.
+
+        Args:
+            html_without_cdata (str): HTML that doesn't contains CDATA tags.
+        """
+        actual_cleaned_html_without_cdata = clean_from_cdata(html_without_cdata)
+
+        assert actual_cleaned_html_without_cdata == html_without_cdata

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from cc2olx.utils import clean_from_cdata
 
 class TestXMLCleaningFromCDATA:
     """
-    Tests XML string cleaning from CDATA sections.
+    Test XML string cleaning from CDATA sections.
     """
 
     def test_cdata_containing_html_is_cleaned_successfully(


### PR DESCRIPTION
## Description
During some OLX nodes creation (HTML, discussions) the entire content is wrapped into `CDATA` tag. But such content can already contain `CDATA` tags inside it, which causes errors. To fix it, the existed `CDATA` tag occurences are deleted (but its content is preserved) before such OLX nodes creation.

## Steps to reproduce
1. Update your Common Cartridge course `.imscc` dump (or use the attached one [cdata_bug_dump.imscc.zip](https://github.com/user-attachments/files/17737015/cdata_bug_dump.imscc.zip) but remove `.zip` extention leaving `.imscc`): add `CDATA` tag to any resource with `webcontent` type.

    For example, let's assume your dump's `imsmanifest.xml` looks like
    ```xml
    <manifest
        xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imscp_v1p1"
        xmlns:lomr="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/resource"
        xmlns:lomm="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/manifest"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="iba028b49-207c-4a5c-a9be-269766ef59e4" xsi:schemaLocation="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/resource http://www.imsglobal.org/profile/cc/ccv1p3/LOM/ccv1p3_lomresource_v1p0.xsd http://www.imsglobal.org/xsd/imsccv1p3/imscp_v1p1 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imscp_v1p2_v1p0.xsd http://ltsc.ieee.org/xsd/imsccv1p3/LOM/manifest http://www.imsglobal.org/profile/cc/ccv1p3/LOM/ccv1p3_lommanifest_v1p0.xsd">
        <metadata>
            <schema>IMS Common Cartridge</schema>
            <schemaversion>1.3.0</schemaversion>
            <lomm:lom>
                <lomm:general>
                    <lomm:title>
                        <lomm:string language="en-US">Advanced Math course</lomm:string>
                    </lomm:title>
                </lomm:general>
            </lomm:lom>
        </metadata>
        <organizations>
            <organization identifier="i30ff4307-bf99-439b-b82b-4c9ff09f7298" structure="rooted-hierarchy">
                <item identifier="i323a3358-8628-4658-ba8b-880db1e0386a">
                    <item identifier="i3ae25411-acfb-46b1-a7ea-a4ec66b7eea0">
                        <title>Week 1 Module</title>
                        <item identifier="i99ed94d4-6f8e-4320-a7b6-ea67356cfedd">
                            <title>Class 1</title>
                            <item identifier="i39520b32-7c2b-44d1-a39f-2dc244c1ac2e" identifierref="i28631a72-ae33-412e-979e-175d55153529_R">
                                <title>Watch: Class 1 Introduction, Outline, Quiz, Bonus Question (1 minute)</title>
                            </item>
                        </item>
                    </item>
                </item>
                <metadata>
                    <lomm:lom/>
                </metadata>
            </organization>
        </organizations>
        <resources>
            <resource identifier="i28631a72-ae33-412e-979e-175d55153529_R" type="webcontent">
                <file href="сontent/i7847e58b-487f-4e39-85ca-23ecfaf4c067/Watch Class 1 Introduction.html"/>
            </resource>
        </resources>
    </manifest>
    ```
    It references to *сontent/i7847e58b-487f-4e39-85ca-23ecfaf4c067/Watch Class 1 Introduction.html* file inside the dump. Let's assume its content looks like
    ```html
    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
        <head>
            <title>CDATA containing HTML document</title>
        </head>
        <body>
            <script type="text/javascript">
                var htmlContent = "<div>Hello, world!</div>";
                alert(htmlContent);
            </script>
        </body>
    </html>
    ```
    For example, let's wrap
    ```js
    var htmlContent = "<div>Hello, world!</div>";
    alert(htmlContent);
    ```
    rows into `CDATA` tag, it will start to look like
    ```html
    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
        <head>
            <title>CDATA containing HTML document</title>
        </head>
        <body>
            <script type="text/javascript">
                // <![CDATA[
                var htmlContent = "<div>Hello, world!</div>";
                alert(htmlContent);
                // ]]>
            </script>
        </body>
    </html>
    ```
2. Run the cc2olx script:
    ```bash
    cc2olx -r zip -i path/to/imscc
    ```
3. See a `ValueError` message:
    ```
    Traceback (most recent call last):
      File "/home/misha/work/cc2olx/src/cc2olx/main.py", line 67, in main
        convert_one_file(input_file, temp_workspace, link_file, passport_file)
      File "/home/misha/work/cc2olx/src/cc2olx/main.py", line 27, in convert_one_file
        olxfile.write(olx_export.xml())
      File "/home/misha/work/cc2olx/src/cc2olx/olx.py", line 64, in xml
        return self.doc.toprettyxml()
      File "/usr/lib/python3.10/xml/dom/minidom.py", line 60, in toprettyxml
        self.writexml(writer, "", indent, newl, encoding, standalone)
      File "/usr/lib/python3.10/xml/dom/minidom.py", line 1828, in writexml
        node.writexml(writer, indent, addindent, newl)
      File "/usr/lib/python3.10/xml/dom/minidom.py", line 897, in writexml
        node.writexml(writer, indent+addindent, addindent, newl)
      File "/usr/lib/python3.10/xml/dom/minidom.py", line 897, in writexml
        node.writexml(writer, indent+addindent, addindent, newl)
      File "/usr/lib/python3.10/xml/dom/minidom.py", line 897, in writexml
        node.writexml(writer, indent+addindent, addindent, newl)
      [Previous line repeated 1 more time]
      File "/usr/lib/python3.10/xml/dom/minidom.py", line 893, in writexml
        self.childNodes[0].writexml(writer, '', '', '')
      File "/usr/lib/python3.10/xml/dom/minidom.py", line 1223, in writexml
        raise ValueError("']]>' not allowed in a CDATA section")
    ValueError: ']]>' not allowed in a CDATA section
    {main.py:78} - Conversion completed
    ```

## Supporting information
FC-0063

## Deadline
"None"