### PR TITLE
fix: QTI support is improved

### DIFF
--- a/tests/fixtures_data/imscc_file/resource_4_qti/assessment_qti.xml
+++ b/tests/fixtures_data/imscc_file/resource_4_qti/assessment_qti.xml
@@ -19,7 +19,7 @@
                 <fieldentry>1</fieldentry>
             </qtimetadatafield>
         </qtimetadata>
-        <section ident="root_section">
+        <section ident="id747a627-25dd-4289-b850-98b134316b50">
             <item ident="question_multiple_choice" title="Question">
                 <itemmetadata>
                     <qtimetadata>
@@ -233,6 +233,47 @@
                     </respcondition>
                 </resprocessing>
             </item>
+            <item ident="question_fill_in_blank_with_regexp">
+                <itemmetadata>
+                    <qtimetadata>
+                        <qtimetadatafield>
+                            <fieldlabel>cc_profile</fieldlabel>
+                            <fieldentry>cc.fib.v0p1</fieldentry>
+                        </qtimetadatafield>
+                        <qtimetadatafield>
+                            <fieldlabel>cc_weighting</fieldlabel>
+                            <fieldentry>1</fieldentry>
+                        </qtimetadatafield>
+                    </qtimetadata>
+                </itemmetadata>
+                <presentation>
+                    <material>
+                        <mattext texttype="text/html">What's the largest city in Switzerland?</mattext>
+                    </material>
+                    <response_str ident="32693">
+                        <render_fib>
+                            <response_label ident="idfe1116d-9876-4e23-8502-5ddcd5a341fc" />
+                        </render_fib>
+                    </response_str>
+                </presentation>
+                <resprocessing>
+                    <outcomes>
+                        <decvar minvalue="0" maxvalue="100" varname="SCORE" vartype="Decimal" />
+                    </outcomes>
+                    <respcondition>
+                        <conditionvar>
+                            <varsubstring respident="32693">Z[uü]rich</varsubstring>
+                        </conditionvar>
+                        <setvar action="Set" varname="SCORE">100</setvar>
+                    </respcondition>
+                    <respcondition continue="Yes">
+                        <conditionvar>
+                            <other />
+                        </conditionvar>
+                        <setvar action="Set" varname="SCORE">0</setvar>
+                    </respcondition>
+                </resprocessing>
+            </item>
             <item ident="essay_question_id" title="Question">
                 <itemmetadata>
                     <qtimetadata>
@@ -269,9 +310,11 @@
                 <itemfeedback ident="essay_solution_id">
                     <solution>
                         <solutionmaterial>
-                            <material>
-                                <mattext texttype="text/html">Sample Answer</mattext>
-                            </material>
+                            <flow_mat>
+                                <material>
+                                    <mattext texttype="text/html">Sample Answer</mattext>
+                                </material>
+                            </flow_mat>
                         </solutionmaterial>
                     </solution>
                 </itemfeedback>

--- a/tests/fixtures_data/studio_course_xml/course.xml
+++ b/tests/fixtures_data/studio_course_xml/course.xml
@@ -71,8 +71,14 @@
 						<textline size="12"/>
 					</stringresponse>
 				</problem>
+                <problem display_name="QTI" url_name="resource_4_qti">
+					<stringresponse answer="Z[uü]rich" type="ci regexp">
+						<p>What's the largest city in Switzerland?</p>
+						<textline size="19"/>
+					</stringresponse>
+				</problem>
 				<html display_name="QTI" url_name="resource_4_qti"><![CDATA[Sample Answer]]></html>
-				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="essay_question_id4">
+				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="essay_question_id5">
 					<title>Open Response Assessment</title>
 					<assessments>
 						<assessment name="staff-assessment" required="True"/>
@@ -102,7 +108,7 @@
 						<feedback_default_text>Feedback prompt default text</feedback_default_text>
 					</rubric>
 				</openassessment>
-				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="essay_question_2_id5">
+				<openassessment text_response="required" prompts_type="html" display_name="QTI" url_name="essay_question_2_id6">
 					<title>Open Response Assessment</title>
 					<assessments>
 						<assessment name="staff-assessment" required="True"/>


### PR DESCRIPTION
## Description
During the cc2olx converter usage with correct Common Cartridge course `.imscc` dumps some problems with CC XML processing were encountered. It caused by handling of special cases by the converter while the actual CC XML can be much more complicated. This PR is intended to solve the encountered problems.
Also, it's found out that cc2olx completely ignores the fact that both OeX "Text Problem" and CC "Fill in the blank" support regexps, so their support is added.

## Steps to reproduce
### Untitled quiz item
1. Update your Common Cartridge course `.imscc` dump (or use the attached one
[untitled_quiz_item_dump.imscc.zip](https://github.com/user-attachments/files/17823352/untitled_quiz_item_dump.imscc.zip) but remove `.zip` extention leaving `.imscc`): ensure you have the `assessment` with `item` that doesn't have `title` attribute.
For example,
    ```xml
    ...
    <assessment ident="i13874147-14c5-4849-93a7-7af746fdd86d" title="Capital Cities of the World">
        ...
        <section ident="root_section">
            <item ident="ic8308415-91d6-4655-a4ba-99db7d0c68b3">
                ...
            </item>
        </section>
        ...
    </assessment>
    ...
    ```
2. Run the cc2olx script:
    ```bash
    cc2olx -i path/to/imscc
    ```
3. See a `KeyError` message.
### Section with not `root_section` identifier
1. Update your Common Cartridge course `.imscc` dump (or use the attached one
[section_with_not_root_section_identifier.imscc.zip](https://github.com/user-attachments/files/17823495/section_with_not_root_section_identifier.imscc.zip) but remove `.zip` extention leaving `.imscc`): ensure you have the `assessment` with `section` which `ident` attribute value isn't `root_section`.  
For example,
    ```xml
    ...
    <assessment ident="i13874147-14c5-4849-93a7-7af746fdd86d" title="Capital Cities of the World">
        ...
        <section ident="id747a627-25dd-4289-b850-98b134316b50">
            ...
        </section>
        ...
    </assessment>
    ...
    ```
2. Run the cc2olx script:
    ```bash
    cc2olx -i path/to/imscc
    ```
3. Explore the output OLX (or use the generated archive for course import in edX) and ensure that the problems from this section are not presented in the course. 
### `respcondition` without `continue` attribute
1. Update your Common Cartridge course `.imscc` dump (or use the attached one [respcondition_without_continue_attribute.imscc.zip](https://github.com/user-attachments/files/17823675/respcondition_without_continue_attribute.imscc.zip) but remove `.zip` extention leaving `.imscc`): ensure you have the `assessment` with `respcondition` without `continue` attribute.  
For example,
    ```xml
    ...
    <assessment ident="i13874147-14c5-4849-93a7-7af746fdd86d" title="Capital Cities of the World">
        ...
        <item ident="ic8308415-91d6-4655-a4ba-99db7d0c68b3" title="The capital city of Australia">
            ...
            <resprocessing>
                ...
                <respcondition>
                    <conditionvar>
                        <varequal respident="i44f42e88-8f56-4a80-9998-567aaacd6c53">i8a6371a5-2741-408e-9f01-8ecec5457f4f</varequal>
                    </conditionvar>
                    <setvar action="Set" varname="SCORE">100</setvar>
                </respcondition>
                ...
            </resprocessing>
            ...
        </item>
        ...
    </assessment>
    ...
    ```
2. Run the cc2olx script:
    ```bash
    cc2olx -i path/to/imscc
    ```
3. See a `KeyError` message.
### `material` is not direct child of `solutionmaterial`
1. Update your Common Cartridge course `.imscc` dump (or use the attached one [material_is_not_direct_child_of_solutionmaterial.zip](https://github.com/user-attachments/files/17823850/material_is_not_direct_child_of_solutionmaterial.zip) but remove `.zip` extention leaving `.imscc`): ensure you have the `assessment` with `itemfeedback`, `itemfeedback` has `solution` child, `solution` has `solutionmaterial`, `material` is not a direct child of `solutionmaterial`: `flow_mat` is a `solutionmaterial` child, `material` is a `flow_mat` child.
For example,
    ```xml
    ...
    <assessment ident="i13874147-14c5-4849-93a7-7af746fdd86d" title="Capital Cities of the World">
        ...
        <item ident="ic8308415-91d6-4655-a4ba-99db7d0c68b3" title="The capital city of Australia">
            ...
            <itemfeedback ident="solution">
                <solution>
                    <solutionmaterial>
                        <flow_mat>
                            <material>
                                <mattext texttype="text/html"></mattext>
                            </material>
                        </flow_mat>
                    </solutionmaterial>
                </solution>
            </itemfeedback>
            <itemfeedback ident="general_fb">
                <flow_mat>
                    <material>
                        <mattext texttype="text/html"></mattext>
                    </material>
                </flow_mat>
            </itemfeedback>
            ...
        </item>
        ...
    </assessment>
    ...
    ```
2. Run the cc2olx script:
    ```bash
    cc2olx -i path/to/imscc
    ```
3. See a `AttributeError` message.
### `Fill in the blank` with regexp
1. Update your Common Cartridge course `.imscc` dump (or use the attached one [fib_with_regexp.imscc.zip](https://github.com/user-attachments/files/17824044/fib_with_regexp.imscc.zip) but remove `.zip` extention leaving `.imscc`): ensure you have the `Fill in the blank` assessment with `resprocessing` that contains `respcondition` with `varsubstring` in `conditionvar`.  
For example,
    ```xml
    ...
    <assessment ident="i13874147-14c5-4849-93a7-7af746fdd86d" title="Capital Cities of the World">
        ...
        <item ident="ic8308415-91d6-4655-a4ba-99db7d0c68b3" title="The largest city in Switzerland">
            ...
            <resprocessing>
                <outcomes>
                    <decvar minvalue="0" maxvalue="100" varname="SCORE" vartype="Decimal" />
                </outcomes>
                <respcondition continue="No">
                    <conditionvar>
                        <varsubstring respident="32693">Z[uü]rich</varsubstring>
                    </conditionvar>
                    <setvar action="Set" varname="SCORE">100</setvar>
                </respcondition>
                <respcondition continue="Yes">
                    <conditionvar>
                        <other />
                    </conditionvar>
                    <setvar action="Set" varname="SCORE">0</setvar>
                </respcondition>
            </resprocessing>
            ...
        </item>
        ...
    </assessment>
    ...
    ```
2. Run the cc2olx script:
    ```bash
    cc2olx -i path/to/imscc
    ```
3. See a `IndexError` message.

## Supporting information
FC-0063

## Deadline
"None"