### PR TITLE
fix: [FC-0063] LTI nodes lookup is fixed

### DIFF
--- a/src/cc2olx/xml/cc_xml.py
+++ b/src/cc2olx/xml/cc_xml.py
@@ -92,7 +92,10 @@ class BasicLtiLink(CommonCartridgeElementBase):
         "lticp": "http://www.imsglobal.org/xsd/imslticp_v1p0",
         "lticm": "http://www.imsglobal.org/xsd/imslticm_v1p0",
     }
-    NODE_NAMESPACES = ["http://www.imsglobal.org/xsd/imslticc_v1p0"]
+    NODE_NAMESPACES = [
+        "http://www.imsglobal.org/xsd/imslticc_v1p0",
+        "http://www.imsglobal.org/xsd/imslticc_v1p3",
+    ]
     NODE_NAME = "cartridge_basiclti_link"
 
     @property


### PR DESCRIPTION
## Description
According to CC [documentation](https://www.imsglobal.org/cc/index.html), LTI nodes for Version 1.2 have `/xsd/imslticc_v1p0` namespace, but the ones for Version 1.3 - `/xsd/imslticc_v1p3`. The converter supported only LTIs Version 1.2, the support of Version 1.3 is added in thid PR.

## Supporting information
FC-0063

## Deadline
"None"